### PR TITLE
fix(chart): allow sa to read metrics

### DIFF
--- a/chart/k8sreq-duplicator-controller/Chart.yaml
+++ b/chart/k8sreq-duplicator-controller/Chart.yaml
@@ -14,4 +14,4 @@ keywords:
 name: k8sreq-duplicator-controller
 sources:
 - https://github.com/DoodleScheduling/k8sreq-duplicator-controller
-version: 0.0.2
+version: 0.0.3

--- a/chart/k8sreq-duplicator-controller/templates/deployment.yaml
+++ b/chart/k8sreq-duplicator-controller/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
         - --upstream=http://127.0.0.1:{{ .Values.metricsPort }}
         - --logtostderr=true
         - --v=0
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        image: {{ .Values.kubeRBACProxy.image }}
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
         ports:

--- a/chart/k8sreq-duplicator-controller/templates/metrics-rbac.yaml
+++ b/chart/k8sreq-duplicator-controller/templates/metrics-rbac.yaml
@@ -17,6 +17,23 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: {{ include "k8sreq-duplicator-controller.fullname" . }}-metrics
+  labels:
+    app.kubernetes.io/name: {{ include "k8sreq-duplicator-controller.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "k8sreq-duplicator-controller.chart" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "k8sreq-duplicator-controller.fullname" . }}-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8sreq-duplicator-controller.serviceAccountName" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: {{ include "k8sreq-duplicator-controller.fullname" . }}-proxy
   labels:
     app.kubernetes.io/name: {{ include "k8sreq-duplicator-controller.name" . }}

--- a/chart/k8sreq-duplicator-controller/templates/metrics-rbac.yaml
+++ b/chart/k8sreq-duplicator-controller/templates/metrics-rbac.yaml
@@ -30,6 +30,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "k8sreq-duplicator-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/chart/k8sreq-duplicator-controller/values.yaml
+++ b/chart/k8sreq-duplicator-controller/values.yaml
@@ -132,6 +132,7 @@ prometheusRule:
 
 kubeRBACProxy:
   enabled: true
+  image: quay.io/brancz/kube-rbac-proxy:v0.14.2
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:

--- a/chart/k8sreq-duplicator-controller/values.yaml
+++ b/chart/k8sreq-duplicator-controller/values.yaml
@@ -88,7 +88,7 @@ securityContext:
     drop: ["all"]
   readOnlyRootFilesystem: true
 
-podSecurityContext:  
+podSecurityContext:
   runAsGroup: 10000
   runAsNonRoot: true
   runAsUser: 10000
@@ -146,5 +146,5 @@ kubeRBACProxy:
   # requests:
   #   cpu: 5m
   #   memory: 64Mi
-    
+
 tolerations: []


### PR DESCRIPTION
## Current situation
The current PodMonitor does not allow to read the metrics with its own token.

## Proposal
Allow the sa token to read the metrics endpoint.
